### PR TITLE
remove query + wagmi providers from landing page

### DIFF
--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ChainProviderFn } from "@wagmi/core"
 import { FC, PropsWithChildren } from "react"
 import { configureChains, createClient, WagmiConfig } from "wagmi"
@@ -167,7 +168,7 @@ const { chains, provider, webSocketProvider } = configureChains(
   enabledNetworks.chains,
   enabledNetworks.providers
 )
-const client = createClient({
+const wagmiClient = createClient({
   autoConnect: true,
   provider,
   webSocketProvider,
@@ -185,8 +186,22 @@ const client = createClient({
   ],
 })
 
-const WagmiProvider: FC<PropsWithChildren> = ({ children }) => {
-  return <WagmiConfig client={client}>{children}</WagmiConfig>
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      retryOnMount: false,
+    },
+  },
+})
+
+const AppProviders: FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <WagmiConfig client={wagmiClient}>{children}</WagmiConfig>
+    </QueryClientProvider>
+  )
 }
 
-export default WagmiProvider
+export default AppProviders

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { FC, PropsWithChildren } from "react"
 
+import AppProviders from "@/components/AppProviders"
 import ConnectWalletModal, {
   DisconnectWalletModal,
 } from "@/components/ConnectWallet/ConnectWalletModal"
@@ -28,7 +29,7 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
   ])
 
   return (
-    <>
+    <AppProviders>
       <div className="relative z-[1] grid min-h-screen grid-cols-1 grid-rows-[auto,1fr,auto]">
         <header className="sticky top-0 z-10 border-b-2 border-[rgba(255,255,255,0.025)] bg-[rgba(255,255,255,0.025)] shadow-2xl backdrop-blur-lg">
           <div className="layout flex items-center justify-between">
@@ -83,7 +84,7 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
         onClose={() => setConnectModal(null)}
         onChange={() => setConnectModal("disconnected")}
       />
-    </>
+    </AppProviders>
   )
 }
 

--- a/src/components/NetworkSelector.tsx
+++ b/src/components/NetworkSelector.tsx
@@ -5,7 +5,7 @@ import { useNetwork, useSwitchNetwork } from "wagmi"
 import clsxm from "@/lib/clsxm"
 import useActiveChainId from "@/hooks/useActiveChainId"
 
-import { enabledNetworks, mainnetFork } from "@/components/WagmiProvider"
+import { enabledNetworks, mainnetFork } from "@/components/AppProviders"
 
 import { useActiveChain } from "@/store/activeChain"
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,8 @@
 import { Inter, VT323 } from "@next/font/google"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { Analytics } from "@vercel/analytics/react"
 import { AppProps } from "next/app"
 
 import "@/styles/globals.css"
-
-import WagmiProvider from "@/components/WagmiProvider"
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
 const vt323 = VT323({
@@ -15,16 +12,6 @@ const vt323 = VT323({
 })
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        retryOnMount: false,
-      },
-    },
-  })
-
   return (
     <>
       <style jsx global>{`
@@ -35,11 +22,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       `}</style>
 
       <div className="font-sans">
-        <QueryClientProvider client={queryClient}>
-          <WagmiProvider>
-            <Component {...pageProps} />
-          </WagmiProvider>
-        </QueryClientProvider>
+        <Component {...pageProps} />
       </div>
 
       <Analytics />

--- a/src/store/activeChain.ts
+++ b/src/store/activeChain.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand"
 
-import { enabledNetworks } from "@/components/WagmiProvider"
+import { enabledNetworks } from "@/components/AppProviders"
 
 export interface ActiveChainStore {
   chainId: number


### PR DESCRIPTION
We don't need to prompt users to connect their wallet on the landing page.