### PR TITLE
Modify the contract link, use the ybTokenAddress

### DIFF
--- a/src/components/Compounder/CompounderVaultTvl.tsx
+++ b/src/components/Compounder/CompounderVaultTvl.tsx
@@ -14,13 +14,13 @@ export const CompounderVaultTvl: FC<VaultProps> = (props) => {
 
   return (
     <div className={clsxm("lg:grid", { "lg:grid-rows-2": !!data })}>
-      <div>
+      <div className="max-lg:hidden">
         <Skeleton isLoading={poolId.isLoading || tvlData.isLoading}>
           {formatCurrencyUnits({ abbreviate: true, amountWei: data.tvl })}
         </Skeleton>
       </div>
       {data.usdTvl && (
-        <div className="text-xs max-lg:hidden">
+        <div className="text-xs max-lg:text-base">
           <Skeleton isLoading={poolId.isLoading || tvlData.isLoading}>
             {formatUsd({ abbreviate: true, amount: data.usdTvl })}
           </Skeleton>

--- a/src/components/Compounder/CompounderVaultTvl.tsx
+++ b/src/components/Compounder/CompounderVaultTvl.tsx
@@ -20,7 +20,7 @@ export const CompounderVaultTvl: FC<VaultProps> = (props) => {
         </Skeleton>
       </div>
       {data.usdTvl && (
-        <div className="text-xs max-lg:text-base">
+        <div className="text-xs max-lg:text-sm">
           <Skeleton isLoading={poolId.isLoading || tvlData.isLoading}>
             {formatUsd({ abbreviate: true, amount: data.usdTvl })}
           </Skeleton>

--- a/src/components/Compounder/CompounderVaultUserBalance.tsx
+++ b/src/components/Compounder/CompounderVaultUserBalance.tsx
@@ -13,11 +13,11 @@ export const CompounderVaultUserBalance: FC<VaultProps> = (props) => {
 
   return (
     <div className={clsxm("lg:grid", { "lg:grid-rows-2": !!balance })}>
-      <div>
+      <div className="max-lg:hidden">
         <AssetBalance address={props.vaultAddress} abbreviate />
       </div>
       {balance && (
-        <div className="text-xs max-lg:hidden">
+        <div className="text-xs max-lg:text-base">
           <AssetBalanceUsd
             asset={props.asset}
             address={props.vaultAddress}

--- a/src/components/Compounder/CompounderVaultUserBalance.tsx
+++ b/src/components/Compounder/CompounderVaultUserBalance.tsx
@@ -17,7 +17,7 @@ export const CompounderVaultUserBalance: FC<VaultProps> = (props) => {
         <AssetBalance address={props.vaultAddress} abbreviate />
       </div>
       {balance && (
-        <div className="text-xs max-lg:text-base">
+        <div className="text-xs max-lg:text-sm">
           <AssetBalanceUsd
             asset={props.asset}
             address={props.vaultAddress}

--- a/src/components/Concentrator/ConcentratorVaultTvl.tsx
+++ b/src/components/Concentrator/ConcentratorVaultTvl.tsx
@@ -13,13 +13,13 @@ export const ConcentratorVaultTvl: FC<VaultProps> = (props) => {
 
   return (
     <div className={clsxm("lg:grid", { "lg:grid-rows-2": !!data })}>
-      <div>
+      <div className="max-lg:hidden">
         <Skeleton isLoading={tvlData.isLoading}>
           {formatCurrencyUnits({ abbreviate: true, amountWei: data.tvl })}
         </Skeleton>
       </div>
       {data.usdTvl && (
-        <div className="text-xs max-lg:hidden">
+        <div className="text-xs max-lg:text-base">
           <Skeleton isLoading={tvlData.isLoading}>
             {formatUsd({ abbreviate: true, amount: data.usdTvl })}
           </Skeleton>

--- a/src/components/Concentrator/ConcentratorVaultTvl.tsx
+++ b/src/components/Concentrator/ConcentratorVaultTvl.tsx
@@ -19,7 +19,7 @@ export const ConcentratorVaultTvl: FC<VaultProps> = (props) => {
         </Skeleton>
       </div>
       {data.usdTvl && (
-        <div className="text-xs max-lg:text-base">
+        <div className="text-xs max-lg:text-sm">
           <Skeleton isLoading={tvlData.isLoading}>
             {formatUsd({ abbreviate: true, amount: data.usdTvl })}
           </Skeleton>

--- a/src/components/Concentrator/ConcentratorVaultUserBalance.tsx
+++ b/src/components/Concentrator/ConcentratorVaultUserBalance.tsx
@@ -18,11 +18,11 @@ export const ConcentratorVaultUserBalance: FC<VaultProps> = (props) => {
 
   return (
     <div className={clsxm("lg:grid", { "lg:grid-rows-2": !!balance })}>
-      <div>
+      <div className="max-lg:hidden">
         <AssetBalance address={concentrator?.data?.ybTokenAddress} abbreviate />
       </div>
       {balance && (
-        <div className="text-xs max-lg:hidden">
+        <div className="text-xs max-lg:text-base">
           <AssetBalanceUsd
             asset={props.vaultAddress}
             address={concentrator?.data?.ybTokenAddress}

--- a/src/components/Concentrator/ConcentratorVaultUserBalance.tsx
+++ b/src/components/Concentrator/ConcentratorVaultUserBalance.tsx
@@ -22,7 +22,7 @@ export const ConcentratorVaultUserBalance: FC<VaultProps> = (props) => {
         <AssetBalance address={concentrator?.data?.ybTokenAddress} abbreviate />
       </div>
       {balance && (
-        <div className="text-xs max-lg:text-base">
+        <div className="text-xs max-lg:text-sm">
           <AssetBalanceUsd
             asset={props.vaultAddress}
             address={concentrator?.data?.ybTokenAddress}

--- a/src/components/Modal/VaultStrategyModal/VaultStrategyModal.tsx
+++ b/src/components/Modal/VaultStrategyModal/VaultStrategyModal.tsx
@@ -63,7 +63,7 @@ export const VaultStrategyModal: FC<
       isOpen={isOpen}
       onClose={onClose}
     >
-      {vaultProps.asset && vaultProps.type && vaultProps.vaultAddress && (
+      {vaultProps.asset && vaultProps.type && vaultProps.ybTokenAddress && (
         <>
           <PurpleModalHeader className="flex justify-between space-x-4">
             <div className="flex space-x-4">
@@ -78,11 +78,11 @@ export const VaultStrategyModal: FC<
                 </Tooltip>
               )}
               {chain?.blockExplorers?.default.url &&
-                vaultProps.vaultAddress && (
+                vaultProps.ybTokenAddress && (
                   <Tooltip label="View contract">
                     <Link
                       className="h-6 w-6 p-[1px]"
-                      href={`${chain.blockExplorers.default.url}/address/${vaultProps.vaultAddress}`}
+                      href={`${chain.blockExplorers.default.url}/address/${vaultProps.ybTokenAddress}`}
                       target="_blank"
                     >
                       <FortIconExternalLink className="h-full w-full" />

--- a/src/components/VaultRow/lib/VaultUserEarnings.tsx
+++ b/src/components/VaultRow/lib/VaultUserEarnings.tsx
@@ -19,7 +19,7 @@ export const VaultUserEarnings: FC<VaultProps> = (props) => {
 
   return isConnected ? (
     <div className="lg:grid lg:grid-rows-2">
-      <div>
+      <div className="max-lg:hidden">
         <Skeleton isLoading={isLoading}>
           {formatCurrencyUnits({
             abbreviate: true,
@@ -28,7 +28,7 @@ export const VaultUserEarnings: FC<VaultProps> = (props) => {
           })}
         </Skeleton>
       </div>
-      <div className="text-xs max-lg:hidden">
+      <div className="text-xs max-lg:text-base">
         <Skeleton isLoading={isLoading}>
           {formatUsd({ abbreviate: true, amount: earnings.data.earnedUSD })}
         </Skeleton>

--- a/src/components/VaultRow/lib/VaultUserEarnings.tsx
+++ b/src/components/VaultRow/lib/VaultUserEarnings.tsx
@@ -28,7 +28,7 @@ export const VaultUserEarnings: FC<VaultProps> = (props) => {
           })}
         </Skeleton>
       </div>
-      <div className="text-xs max-lg:text-base">
+      <div className="text-xs max-lg:text-sm">
         <Skeleton isLoading={isLoading}>
           {formatUsd({ abbreviate: true, amount: earnings.data.earnedUSD })}
         </Skeleton>


### PR DESCRIPTION
Use the ybTokenAddress instead of the vaultAddress, as for the concentrator vaultAddress point to the primary Asset.
Display the dollar value for TVL/Balance and Earning in mobile view